### PR TITLE
Refactor inline styles in 3 hotspot case studies to shared utilities

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -318,6 +318,9 @@
     /* Video/embed frame — used on every case study */
     .video-frame    { padding: 0; border-radius: 4px; overflow: hidden; }
 
+    /* Filled grey tag pill — distinct from .tag-pill (which is the bordered/outline variant on the index grid) */
+    .tag-chip       { background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
+
     /* Responsive visibility — paired with overrides inside the 800px media query */
     .hidden-desktop { display: none; }
 
@@ -2721,7 +2724,7 @@ filter: invert(75%) sepia(10%) saturate(1296%) hue-rotate(173deg) brightness(94%
         #portfolioContent,
         .casestudy{
           padding-left: 40px;
-          padding-right: 40px;
+          padding-right: 40Cpx;
           margin-left: 0;
           margin-right: 0;
           max-width: 100%;

--- a/files/hashi/mlm/mlm.html
+++ b/files/hashi/mlm/mlm.html
@@ -68,21 +68,8 @@
     </ul>
     <button class="hamburger">
       <i class="menuIcon material-icons">menu</i>
-      <i class="closeIcon material-icons" style="display: none;">close</i>
-    </button></a>
-  </li>
-
- 
-
-
-    <!--Some Hamburger that will always show up-->
-  </ul>
-  <button class="hamburger" 
- >
-    <!-- material icons https://material.io/resources/icons/ -->
-    <i class="menuIcon material-icons">menu</i>
-    <i class="closeIcon material-icons" style="display: none;">close</i>
-  </button>
+      <i class="closeIcon material-icons hidden">close</i>
+    </button>
 
 
   
@@ -208,7 +195,7 @@
           <div class="subtitle">SOLUTION PREVIEW</div>
             <div class="solutionPre" style="margin-top:-80px;" >
             <div class="block">
-              <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop style=" padding: 0px; border-radius: 4px;" >
+              <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop class="video-frame" >
                 <source src="./MLMPrototype.mp4">
               </video>
             </div>
@@ -239,7 +226,7 @@
                     <div style="width: 72px; height: 72px; border-radius: 8px; background: var(--background); border: 1px solid var(--bordercolor); display: flex; align-items: center; justify-content: center; font-size: 32px; flex-shrink: 0;">🧑‍💼</div>
                     <div>
                         <p style="margin: 0 0 8px; font-style: italic; color: var(--primarytext);">Arthur the module <strong>author</strong></p>
-                        <p style="margin: 0; color: var(--primarytext);">Arthur is the Terraform expert in their company, and releases modules, which are predefined reusable packages of software. He distributes this to module consumers.</p>
+                        <p class="margin-0 text-primary-color">Arthur is the Terraform expert in their company, and releases modules, which are predefined reusable packages of software. He distributes this to module consumers.</p>
                     </div>
                 </div>
 
@@ -247,7 +234,7 @@
                     <div style="width: 72px; height: 72px; border-radius: 8px; background: var(--background); border: 1px solid var(--bordercolor); display: flex; align-items: center; justify-content: center; font-size: 32px; flex-shrink: 0;">👩‍💻</div>
                     <div>
                         <p style="margin: 0 0 8px; font-style: italic; color: var(--primarytext);">Coco the module <strong>consumer</strong></p>
-                        <p style="margin: 0; color: var(--primarytext);">This individual is an application developer for their company, and uses Terraform to provision infrastructure. They consume modules and use it through a Terraform Run.</p>
+                        <p class="margin-0 text-primary-color">This individual is an application developer for their company, and uses Terraform to provision infrastructure. They consume modules and use it through a Terraform Run.</p>
                     </div>
                 </div>
             </div>
@@ -261,12 +248,12 @@
                 <div style="display: flex; flex-direction: column; gap: 16px;">
                     <div style="display: flex; gap: 12px; align-items: flex-start;">
                         <span style="display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 50%; background: var(--background); border: 1px solid var(--bordercolor); font-size: 14px; flex-shrink: 0;">🧑‍💼</span>
-                        <p style="margin: 0; color: var(--primarytext);"><strong><em>Arthur the module author</em></strong> realizes that a module has an issue with security vulnerabilities in the cloud provider</p>
+                        <p class="margin-0 text-primary-color"><strong><em>Arthur the module author</em></strong> realizes that a module has an issue with security vulnerabilities in the cloud provider</p>
                     </div>
 
                     <div style="display: flex; gap: 12px; align-items: center;">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="28" height="28" style="flex-shrink:0; border-radius:5px;"><mask id="vscode-mask" width="128" height="128" x="0" y="0" maskUnits="userSpaceOnUse" style="mask-type:alpha"><path fill="#fff" fill-rule="evenodd" d="M90.767 127.126a7.968 7.968 0 0 0 6.35-.244l26.353-12.681a8 8 0 0 0 4.53-7.209V21.009a8 8 0 0 0-4.53-7.21L97.117 1.12a7.97 7.97 0 0 0-9.093 1.548l-50.45 46.026L15.6 32.013a5.328 5.328 0 0 0-6.807.302l-7.048 6.411a5.335 5.335 0 0 0-.006 7.888L20.796 64 1.74 81.387a5.336 5.336 0 0 0 .006 7.887l7.048 6.411a5.327 5.327 0 0 0 6.807.303l21.974-16.68 50.45 46.025a7.96 7.96 0 0 0 2.743 1.793Zm5.252-92.183L57.74 64l38.28 29.058V34.943Z" clip-rule="evenodd"/></mask><g mask="url(#vscode-mask)"><path fill="#0065A9" d="M123.471 13.82 97.097 1.12A7.973 7.973 0 0 0 88 2.668L1.662 81.387a5.333 5.333 0 0 0 .006 7.887l7.052 6.411a5.333 5.333 0 0 0 6.811.303l103.971-78.875c3.488-2.646 8.498-.158 8.498 4.22v-.306a8.001 8.001 0 0 0-4.529-7.208Z"/><path fill="#007ACC" d="m123.471 114.181-26.374 12.698A7.973 7.973 0 0 1 88 125.333L1.662 46.613a5.333 5.333 0 0 1 .006-7.887l7.052-6.411a5.333 5.333 0 0 1 6.811-.303l103.971 78.874c3.488 2.647 8.498.159 8.498-4.219v.306a8.001 8.001 0 0 1-4.529 7.208Z"/><path fill="#1F9CF0" d="M97.098 126.882A7.977 7.977 0 0 1 88 125.333c2.952 2.952 8 .861 8-3.314V5.98c0-4.175-5.048-6.266-8-3.313a7.977 7.977 0 0 1 9.098-1.549L123.467 13.8A8 8 0 0 1 128 21.01v85.982a8 8 0 0 1-4.533 7.21l-26.369 12.681Z"/></g></svg>
-                        <p style="margin: 0; color: var(--primarytext);">so he then creates patch version</p>
+                        <p class="margin-0 text-primary-color">so he then creates patch version</p>
                     </div>
 
                     <div style="display: flex; gap: 12px; align-items: center;">
@@ -275,7 +262,7 @@
                             <path d="M81.41 81.336l31.633-18.418V26.082L81.41 44.5zm0 0" fill="#4040b2"/>
                             <path d="M11.242 42.36L42.86 60.776V23.941L11.242 5.523zm0 0M77.941 85.375L46.324 66.957v36.82l31.617 18.418zm0 0" fill="#5c4ee5"/>
                         </svg>
-                        <p style="margin: 0; color: var(--primarytext);">then he publishes to the private registry in their organization</p>
+                        <p class="margin-0 text-primary-color">then he publishes to the private registry in their organization</p>
                     </div>
 
                     <div style="display: flex; gap: 12px; align-items: center;">
@@ -285,12 +272,12 @@
                             <path d="M100.745 47.281c0-7.33 5.978-13.317 13.309-13.317 7.33 0 13.317 5.987 13.317 13.317s-5.987 13.317-13.317 13.317h-13.309zm-6.709 0c0 7.33-5.987 13.317-13.317 13.317s-13.317-5.986-13.317-13.317V13.946C67.402 6.616 73.388.63 80.719.63c7.33 0 13.317 5.987 13.317 13.317zm0 0" fill="#2eb57d"/>
                             <path d="M80.719 100.745c7.33 0 13.317 5.978 13.317 13.309 0 7.33-5.987 13.317-13.317 13.317s-13.317-5.987-13.317-13.317v-13.309zm0-6.709c-7.33 0-13.317-5.987-13.317-13.317s5.986-13.317 13.317-13.317h33.335c7.33 0 13.317 5.986 13.317 13.317 0 7.33-5.987 13.317-13.317 13.317zm0 0" fill="#ebb02e"/>
                         </svg>
-                        <p style="margin: 0; color: var(--primarytext);">Now he needs to communicate to the 1k end users in the organization <span style="color: #E5386D; font-weight: 500;">← Friction</span></p>
+                        <p class="margin-0 text-primary-color">Now he needs to communicate to the 1k end users in the organization <span style="color: #E5386D; font-weight: 500;">← Friction</span></p>
                     </div>
 
                     <div style="display: flex; gap: 12px; align-items: flex-start;">
                         <span style="display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 50%; background: var(--background); border: 1px solid var(--bordercolor); font-size: 14px; flex-shrink: 0;">👩‍💻</span>
-                        <p style="margin: 0; color: var(--primarytext);"><strong><em>Coco the module consumer</em></strong> needs to read message <span style="color: #E5386D; font-weight: 500;">← What happens if they never do this?</span></p>
+                        <p class="margin-0 text-primary-color"><strong><em>Coco the module consumer</em></strong> needs to read message <span style="color: #E5386D; font-weight: 500;">← What happens if they never do this?</span></p>
                     </div>
 
                     <div style="display: flex; gap: 12px; align-items: center;">
@@ -299,7 +286,7 @@
                             <path d="M81.41 81.336l31.633-18.418V26.082L81.41 44.5zm0 0" fill="#4040b2"/>
                             <path d="M11.242 42.36L42.86 60.776V23.941L11.242 5.523zm0 0M77.941 85.375L46.324 66.957v36.82l31.617 18.418zm0 0" fill="#5c4ee5"/>
                         </svg>
-                        <p style="margin: 0; color: var(--primarytext);">and change the module version in their terraform configuration</p>
+                        <p class="margin-0 text-primary-color">and change the module version in their terraform configuration</p>
                     </div>
                 </div>
             </div>
@@ -317,7 +304,7 @@
 
                 <div style="display: flex; gap: 10px; align-items: center; margin-bottom: 20px;">
                     <span style="display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 50%; background: var(--background); border: 1px solid var(--bordercolor); font-size: 14px; flex-shrink: 0;">🧑‍💼</span>
-                    <p style="margin: 0; color: var(--primarytext);"><strong><em>Arthur the module author</em></strong> is frustrated with this problem, so what do they do?</p>
+                    <p class="margin-0 text-primary-color"><strong><em>Arthur the module author</em></strong> is frustrated with this problem, so what do they do?</p>
                 </div>
 
                 <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
@@ -395,7 +382,7 @@
 
                 </p>
 
-                 <div class="rowcard" style="margin-top: 24px;">
+                 <div class="rowcard margin-top-24">
                     <div class="gencard">
                       <h3>Communication to end users</h3>
                       <p>Module consumer Persona</p>
@@ -455,7 +442,7 @@
             <H4>The full prototype from module author persona to the linking with the module consumer persona.</H4>
                 <div class="solutionPre margin-top" >
                 <div class="block">
-                  <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop style=" padding: 0px; border-radius: 4px;" >
+                  <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop class="video-frame" >
                     <source src="./MLMPrototype.mp4">
                   </video>
                 </div>
@@ -561,7 +548,7 @@
     </div>
    
     
-    <p class="center" style="margin-top: 8px; margin-bottom: 8px;">© Ishaan Bose, 2026</p>
+    <p class="center margin-y-8">© Ishaan Bose, 2026</p>
 
     <!-- Website scripts -->
     <script src="assets/js/app.js"></script>

--- a/files/hashi/tags/tags.html
+++ b/files/hashi/tags/tags.html
@@ -110,20 +110,8 @@
     </ul>
     <button class="hamburger">
       <i class="menuIcon material-icons">menu</i>
-      <i class="closeIcon material-icons" style="display: none;">close</i>
-    </button></a>
-      </li>
-
-    
-
-
-        <!--Some Hamburger that will always show up-->
-      </ul>
-      <button class="hamburger" >
-        <!-- material icons https://material.io/resources/icons/ -->
-        <i class="menuIcon material-icons">menu</i>
-        <i class="closeIcon material-icons" style="display: none;">close</i>
-      </button>
+      <i class="closeIcon material-icons hidden">close</i>
+    </button>
               <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NRTS34N"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -207,7 +195,7 @@
               <div class="subtitle">SOLUTION PREVIEW</div>
                 <div class="solutionPre" style="margin-top:-80px;" >
                 <div class="block">
-                  <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop style=" padding: 0px; border-radius: 4px;" >
+                  <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop class="video-frame" >
                     <source src="./NonTalkThroughTagProto.mp4">
                   </video>
                 </div>
@@ -261,7 +249,7 @@
                 </div>
 
                 <!-- sentiment timeline -->
-                <div style="margin-top: 16px;">
+                <div class="margin-top-16">
                   <div style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 16px; margin-bottom: 6px;">
                     <p style="font-size: 12px; color: var(--secondarytext); font-style: italic; line-height: 1.5;">"We are power users of Terraform Cloud and have thousands of resources on the platform"</p>
                     <div></div><div></div><div></div>
@@ -301,24 +289,24 @@
                     <div style="display: flex; gap: 12px; height: calc(100% - 44px);">
                       <div style="flex: 1; border: 2px solid #22c55e; border-radius: 8px; padding: 14px; display: flex; flex-direction: column; justify-content: space-between;">
                         <div style="display: flex; flex-wrap: wrap; gap: 8px;">
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">autoapply : on</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">contact : billy</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">hasDeprecatedModule</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">localexecution</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">env : prod</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">new</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">tfversion1.8</span>
+                          <span class="tag-chip">autoapply : on</span>
+                          <span class="tag-chip">contact : billy</span>
+                          <span class="tag-chip">hasDeprecatedModule</span>
+                          <span class="tag-chip">localexecution</span>
+                          <span class="tag-chip">env : prod</span>
+                          <span class="tag-chip">new</span>
+                          <span class="tag-chip">tfversion1.8</span>
                         </div>
                         <p style="color: #22c55e; margin-top: 14px; font-size: 13px; font-weight: 500;">Arbitrary tags (often single value)</p>
                       </div>
                       <div style="flex: 1; border: 2px solid var(--accent); border-radius: 8px; padding: 14px; display: flex; flex-direction: column; justify-content: space-between;">
                         <div style="display: flex; flex-wrap: wrap; gap: 8px;">
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">costcenter : rnd</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">env : prod</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">BillingID : 128413</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">service : CloudFeed</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">Owner : ishaan</span>
-                          <span style="background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px;">project : tf-new-compute</span>
+                          <span class="tag-chip">costcenter : rnd</span>
+                          <span class="tag-chip">env : prod</span>
+                          <span class="tag-chip">BillingID : 128413</span>
+                          <span class="tag-chip">service : CloudFeed</span>
+                          <span class="tag-chip">Owner : ishaan</span>
+                          <span class="tag-chip">project : tf-new-compute</span>
                         </div>
                         <p style="color: var(--accent); margin-top: 14px; font-size: 13px; font-weight: 500;">Administrative tags (often k/v)</p>
                       </div>
@@ -415,7 +403,7 @@
 
                   <div class="solutionPre margin-top-lg" >
                   <div class="block">
-                    <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop style=" padding: 0px; border-radius: 4px;" >
+                    <video controls="controls" width="100%" height="100%" name="Tag preview" controls muted autoplay loop class="video-frame" >
                       <source src="./NonTalkThroughTagProto.mp4">
                     </video>
                   </div>
@@ -514,7 +502,7 @@
     </div>
    
     
-    <p class="center" style="margin-top: 8px; margin-bottom: 8px;">© Ishaan Bose, 2026</p>
+    <p class="center margin-y-8">© Ishaan Bose, 2026</p>
 
     <!-- Website scripts -->
     <script src="assets/js/app.js"></script>

--- a/files/hashi/workspacerecovery/recovery.html
+++ b/files/hashi/workspacerecovery/recovery.html
@@ -92,14 +92,7 @@
     </ul>
     <button class="hamburger">
       <i class="menuIcon material-icons">menu</i>
-      <i class="closeIcon material-icons" style="display: none;">close</i>
-    </button>
-          </a>
-        </li>
-    </ul>
-    <button class="hamburger">
-        <i class="menuIcon material-icons">menu</i>
-        <i class="closeIcon material-icons" style="display: none;">close</i>
+      <i class="closeIcon material-icons hidden">close</i>
     </button>
 
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NRTS34N"
@@ -175,10 +168,10 @@
                           <div style="font-size: 11px; color: var(--primarytext); font-weight: 500;">prod-infra-west</div>
                           <div style="font-size: 9px; color: #BBB; margin-top: 1px;">ws-8f3a209c4b1e</div>
                         </div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">Core Cloud Infra</div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">Nov 15, 2025 · 20:41Z</div>
+                        <div class="text-xs text-secondary-color">Core Cloud Infra</div>
+                        <div class="text-xs text-secondary-color">Nov 15, 2025 · 20:41Z</div>
                         <div style="font-size: 11px; color: #b45309;">⚠ 1 day</div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">0</div>
+                        <div class="text-xs text-secondary-color">0</div>
                         <div style="font-size: 13px; color: #CCC; padding-left: 4px;">···</div>
                       </div>
 
@@ -188,10 +181,10 @@
                           <div style="font-size: 11px; color: var(--primarytext); font-weight: 500;">staging-app-east</div>
                           <div style="font-size: 9px; color: #BBB; margin-top: 1px;">ws-4b9c7e2a1d8f</div>
                         </div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">App Deployment</div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">Nov 16, 2025 · 18:22Z</div>
+                        <div class="text-xs text-secondary-color">App Deployment</div>
+                        <div class="text-xs text-secondary-color">Nov 16, 2025 · 18:22Z</div>
                         <div style="font-size: 11px; color: #b45309;">⚠ 2 days</div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">0</div>
+                        <div class="text-xs text-secondary-color">0</div>
                         <div style="display: flex; align-items: center;">
                           <div style="background: rgba(123,66,188,0.1); border: 1px solid rgba(123,66,188,0.3); border-radius: 4px; padding: 3px 8px; font-size: 10px; color: var(--terraform); white-space: nowrap; font-weight: 500;">↩ Recover</div>
                         </div>
@@ -203,10 +196,10 @@
                           <div style="font-size: 11px; color: var(--primarytext); font-weight: 500;">nomad-cluster</div>
                           <div style="font-size: 9px; color: #BBB; margin-top: 1px;">st-2d7f1a90c3c6e</div>
                         </div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">Network Config</div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">Nov 17, 2025 · 14:36Z</div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">4 days</div>
-                        <div style="font-size: 11px; color: var(--secondarytext);">0</div>
+                        <div class="text-xs text-secondary-color">Network Config</div>
+                        <div class="text-xs text-secondary-color">Nov 17, 2025 · 14:36Z</div>
+                        <div class="text-xs text-secondary-color">4 days</div>
+                        <div class="text-xs text-secondary-color">0</div>
                         <div style="font-size: 13px; color: #CCC; padding-left: 4px;">···</div>
                       </div>
 
@@ -255,7 +248,7 @@
             <div class="block" id="problem">
               <div class="subtitle">PROBLEM</div>
               <h4>Workspace Recovery started with a question that sounded small: what should happen when someone accidentally deletes an HCP Terraform workspace?</h4>
-              <p style="margin-top: 24px;">In HCP Terraform, a workspace is not just a project container. It holds the state, variables, history, and workflow context needed to manage real infrastructure over time. Deletion could wipe all of that, with no native path to get it back.</p>
+              <p class="margin-top-24">In HCP Terraform, a workspace is not just a project container. It holds the state, variables, history, and workflow context needed to manage real infrastructure over time. Deletion could wipe all of that, with no native path to get it back.</p>
 
 
                  <div style="margin-top: 1.5rem; display: flex; flex-direction: column; gap: 24px;">
@@ -394,7 +387,7 @@
                 </div>
 
               </div>
-              <p style="margin-top: 16px;">That mismatch shaped the whole problem. Recovery had to fit the reality of enterprise operations, not just the UI. I partnered with my PM to frame the work around three questions: how accidental deletion actually happened, what a believable recovery path should bring back, and how customers were already trying to protect themselves from this risk.</p>
+              <p class="margin-top-16">That mismatch shaped the whole problem. Recovery had to fit the reality of enterprise operations, not just the UI. I partnered with my PM to frame the work around three questions: how accidental deletion actually happened, what a believable recovery path should bring back, and how customers were already trying to protect themselves from this risk.</p>
             </div>
 
 
@@ -605,7 +598,7 @@
               <div class="subtitle">OUTCOME</div>
               <h4>A recurring customer request became a defined, buildable MVP called Recoverable Items.</h4>
               <p>By the end of the project, the team had aligned on an in-product recovery concept scoped around accidentally deleted workspaces and stacks, organization-level access, a 30-day retention window, and a recovery run that restores the workspace "as if it were never deleted."</p>
-              <p style="margin-top: 16px;">The design work also clarified what was explicitly out of scope: full audit history, unlimited retention, n-2 rollback, and a generic archival system. An internal demo described the feature as a gamechanger for customers, and the design work formed the basis for that impact.</p>
+              <p class="margin-top-16">The design work also clarified what was explicitly out of scope: full audit history, unlimited retention, n-2 rollback, and a generic archival system. An internal demo described the feature as a gamechanger for customers, and the design work formed the basis for that impact.</p>
 
               <div class="row margin-top">
                 <div class="gencard margin-top">
@@ -628,7 +621,7 @@
               <div class="subtitle">CONCLUSION</div>
               <h4>Enterprise UX is often about designing for failure. Good product judgment shows up in what you choose not to build.</h4>
               <p>The hard part of this project was not drawing an "undelete" flow. It was understanding the system around the failure: who caused it, who owned the recovery, what data actually mattered, and where a tightly scoped fix could accidentally become a much larger platform promise.</p>
-              <p style="margin-top: 16px;">By keeping the work focused on high-confidence recovery instead of generalized rollback or archival, I helped the team move from reacting to a feature request to defining something more coherent and buildable. The project also reinforced something I come back to often: in enterprise software, the real user of a recovery feature is usually not the person who made the mistake.</p>
+              <p class="margin-top-16">By keeping the work focused on high-confidence recovery instead of generalized rollback or archival, I helped the team move from reacting to a feature request to defining something more coherent and buildable. The project also reinforced something I come back to often: in enterprise software, the real user of a recovery feature is usually not the person who made the mistake.</p>
             </div>
 
           </div>
@@ -666,7 +659,7 @@
       <a href="mailto:ishaan.bose@gmail.com" target="_blank"><img class="sm_icon_center" src="../../../assets/send-4008.svg"></a>
     </div>
 
-    <p class="center" style="margin-top: 8px; margin-bottom: 8px;">© Ishaan Bose, 2026</p>
+    <p class="center margin-y-8">© Ishaan Bose, 2026</p>
 
     <script
       type="module"


### PR DESCRIPTION
## Summary
PR 2 of the inline-style refactor. Replaces 51 repeated inline `style="..."` attributes across the three heaviest case studies with classes from the shared stylesheet introduced in #40.

| File | Before | After | Removed |
|---|---|---|---|
| [files/hashi/workspacerecovery/recovery.html](files/hashi/workspacerecovery/recovery.html) | 197 | 180 | -17 |
| [files/hashi/tags/tags.html](files/hashi/tags/tags.html) | 64 | 45 | -19 |
| [files/hashi/mlm/mlm.html](files/hashi/mlm/mlm.html) | 65 | 50 | -15 |

The remaining ~275 inline styles across the three files are page-specific one-offs (unique colors, fixed widths, custom positioning) used fewer than 3 times — those stay inline since extracting them into shared classes would bloat the stylesheet for no reuse benefit.

### Substitutions applied
- `style="display: none;"` → `class="hidden"`
- `style="font-size: 11px; color: var(--secondarytext);"` → `class="text-xs text-secondary-color"`
- `style="margin: 0; color: var(--primarytext);"` → `class="margin-0 text-primary-color"`
- `style="margin-top: 8px; margin-bottom: 8px;"` → `class="margin-y-8"`
- `style="margin-top: 16px;"` / `style="margin-top: 24px;"` → corresponding utilities
- `style=" padding: 0px; border-radius: 4px;"` (video frames) → `class="video-frame"`
- Tags-page filled-grey pill (13× in tags.html) → new `.tag-chip` utility

### New class
- `.tag-chip` — filled grey pill (`background: #d4d4d4; border-radius: 999px; padding: 5px 12px; font-size: 13px`). Distinct from the existing `.tag-pill` which is the bordered/outline variant used on the index grid.

### Cleanup
- Removed duplicate `<button class="hamburger">` markup in all three files (copy-paste artifact from `porttemplate.html` — each file had a stray second hamburger button with no functional purpose).

## Dependency
This PR depends on #40 (foundation utilities). GitHub should auto-retarget when #40 merges, otherwise rebase.

## Test plan
- [ ] Load each of the three case studies at 1440px and 375px viewports
- [ ] Tag pills on [files/hashi/tags/tags.html](files/hashi/tags/tags.html) (lines ~300) look pixel-identical to before
- [ ] Video frames on all three pages render without changed padding/radius
- [ ] Secondary 11px captions across recovery.html render at the same color/size
- [ ] No new DOM bloat — exactly one `<button class="hamburger">` per page
- [ ] No console errors

Generated with [Claude Code](https://claude.com/claude-code)
