### PR TITLE
Smooth hover video transitions on index cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1847,6 +1847,16 @@ filter: invert(75%) sepia(10%) saturate(1296%) hue-rotate(173deg) brightness(94%
 
     .card-img { overflow: hidden; border-radius: 12px 12px 0 0; }
     .card-img img { width: 100%; display: block; object-fit: cover; }
+    .card-img video {
+      opacity: 0;
+      transition: opacity 260ms ease;
+      pointer-events: none;
+      padding: 0;
+      margin: 0;
+      display: block;
+      box-sizing: border-box;
+    }
+    .card-img:hover video { opacity: 1; }
 
     .card-blank { min-height: 340px; }
 

--- a/index.html
+++ b/index.html
@@ -138,14 +138,14 @@
         <!-- Card 1: Blank — Remediation Agent (NDA) -->
         <a href="./files/hashi/remediationagent/agent.html">
           <div class="card-new card-blank rowhover">
-                        <div class="card-img" style="aspect-ratio: 2224/1796; position: relative;"
-                 onmouseenter="this.querySelector('img').style.display='none';var v=this.querySelector('video');v.style.display='block';v.play();"
-                 onmouseleave="this.querySelector('img').style.display='block';var v=this.querySelector('video');v.pause();v.currentTime=0;v.style.display='none';">
+            <div class="card-img" style="aspect-ratio: 2224/1796; position: relative;"
+                 onmouseenter="this.querySelector('video').play();"
+                 onmouseleave="var v=this.querySelector('video');v.pause();v.currentTime=0;">
               <picture>
                 <source srcset="./images/remediationimg.webp" type="image/webp">
                 <img src="./images/remediationimg.png" alt="RemediationAgent" style="width:100%;height:100%;object-fit:cover;">
               </picture>
-              <video src="./images/agent.mp4" loop muted playsinline style="display:none;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
+              <video src="./images/agent.mp4" poster="./images/remediationimg.png" preload="auto" loop muted playsinline style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
             </div>
             <div class="card-body">
               <div class="card-header-row">
@@ -167,13 +167,13 @@
         <a href="files/hashi/workspacerecovery/recovery.html">
           <div class="card-new rowhover">
             <div class="card-img" style="aspect-ratio: 2224/1820; position: relative;"
-                 onmouseenter="this.querySelector('img').style.display='none';var v=this.querySelector('video');v.style.display='block';v.play();"
-                 onmouseleave="this.querySelector('img').style.display='block';var v=this.querySelector('video');v.pause();v.currentTime=0;v.style.display='none';">
+                 onmouseenter="this.querySelector('video').play();"
+                 onmouseleave="var v=this.querySelector('video');v.pause();v.currentTime=0;">
               <picture>
                 <source srcset="./images/workspacerecoverimg.webp" type="image/webp">
                 <img src="./images/workspacerecoverimg.png" alt="Recoverable Items" style="width:100%;height:100%;object-fit:cover;">
               </picture>
-              <video src="./images/recover.mp4" loop muted playsinline style="display:none;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
+              <video src="./images/recover.mp4" poster="./images/workspacerecoverimg.png" preload="auto" loop muted playsinline style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
             </div>
             <div class="card-body">
               <div class="card-header-row">
@@ -195,13 +195,13 @@
         <a href="files/hashi/tags/tags.html">
           <div class="card-new rowhover">
             <div class="card-img" style="aspect-ratio: 2224/1820; position: relative;"
-                 onmouseenter="this.querySelector('img').style.display='none';var v=this.querySelector('video');v.style.display='block';v.play();"
-                 onmouseleave="this.querySelector('img').style.display='block';var v=this.querySelector('video');v.pause();v.currentTime=0;v.style.display='none';">
+                 onmouseenter="this.querySelector('video').play();"
+                 onmouseleave="var v=this.querySelector('video');v.pause();v.currentTime=0;">
               <picture>
                 <source srcset="./images/kvtagimg.webp" type="image/webp">
                 <img src="./images/kvtagimg.png" alt="Key Value Tags" loading="lazy" style="width:100%;height:100%;object-fit:cover;">
               </picture>
-              <video src="./images/alttag.mp4" loop muted playsinline style="display:none;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
+              <video src="./images/alttag.mp4" poster="./images/kvtagimg.png" preload="auto" loop muted playsinline style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
             </div>
             <div class="card-body">
               <div class="card-header-row">
@@ -223,13 +223,13 @@
         <a href="files/hashi/mlm/mlm.html">
           <div class="card-new rowhover">
             <div class="card-img" style="aspect-ratio: 2224/1820; position: relative;"
-                 onmouseenter="this.querySelector('img').style.display='none';var v=this.querySelector('video');v.style.display='block';v.play();"
-                 onmouseleave="this.querySelector('img').style.display='block';var v=this.querySelector('video');v.pause();v.currentTime=0;v.style.display='none';">
+                 onmouseenter="this.querySelector('video').play();"
+                 onmouseleave="var v=this.querySelector('video');v.pause();v.currentTime=0;">
               <picture>
                 <source srcset="./images/mlmimg.webp" type="image/webp">
                 <img src="./images/mlmimg.png" alt="Module Lifecycle Management" loading="lazy" style="width:100%;height:100%;object-fit:cover;">
               </picture>
-              <video src="./images/mlm.mp4" loop muted playsinline style="display:none;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
+              <video src="./images/mlm.mp4" poster="./images/mlmimg.png" preload="auto" loop muted playsinline style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
             </div>
             <div class="card-body">
               <div class="card-header-row">
@@ -251,13 +251,13 @@
         <a href="files/hashi/uirefresh/uirefresh.html">
           <div class="card-new rowhover">
             <div class="card-img" style="aspect-ratio: 2224/1820; position: relative;"
-                 onmouseenter="this.querySelector('img').style.display='none';var v=this.querySelector('video');v.style.display='block';v.play();"
-                 onmouseleave="this.querySelector('img').style.display='block';var v=this.querySelector('video');v.pause();v.currentTime=0;v.style.display='none';">
+                 onmouseenter="this.querySelector('video').play();"
+                 onmouseleave="var v=this.querySelector('video');v.pause();v.currentTime=0;">
               <picture>
                 <source srcset="./images/uirefreshimg.webp" type="image/webp">
                 <img src="./images/uirefreshimg.png" alt="HCP Terraform UI Refresh" loading="lazy" style="width:100%;height:100%;object-fit:cover;">
               </picture>
-              <video src="./images/uirefresh.mp4" loop muted playsinline style="display:none;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
+              <video src="./images/uirefresh.mp4" poster="./images/uirefreshimg.png" preload="auto" loop muted playsinline style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
             </div>
             <div class="card-body">
               <div class="card-header-row">
@@ -279,13 +279,13 @@
         <a href="files/hashi/imageusage/hashi.html">
           <div class="card-new rowhover">
             <div class="card-img" style="aspect-ratio: 2224/1820; position: relative;"
-                 onmouseenter="this.querySelector('img').style.display='none';var v=this.querySelector('video');v.style.display='block';v.play();"
-                 onmouseleave="this.querySelector('img').style.display='block';var v=this.querySelector('video');v.pause();v.currentTime=0;v.style.display='none';">
+                 onmouseenter="this.querySelector('video').play();"
+                 onmouseleave="var v=this.querySelector('video');v.pause();v.currentTime=0;">
               <picture>
                 <source srcset="./images/packerimg.webp" type="image/webp">
                 <img src="./images/packerimg.png" alt="Image Usage Insights" loading="lazy" style="width:100%;height:100%;object-fit:cover;">
               </picture>
-              <video src="./images/packer.mp4" loop muted playsinline style="display:none;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
+              <video src="./images/packer.mp4" poster="./images/packerimg.png" preload="auto" loop muted playsinline style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;"></video>
             </div>
             <div class="card-body">
               <div class="card-header-row">


### PR DESCRIPTION
## Summary
- Replace `display: none` toggle with an opacity crossfade (260ms) on `.card-img video`, so the static cover and the hover video swap smoothly instead of hard-cutting.
- Add `poster="<cover image>"` and `preload="auto"` to each card video so the element shows the cover image (not a black flash) while the first frame decodes.
- Override the global `video { padding: 24px; margin: auto; }` rule for `.card-img video` — it was offsetting the absolutely-positioned video inside the card box and made the playing video look misaligned vs. the static image.

## Test plan
- [ ] Hover each of the 6 HashiCorp cards on `index.html` — video fades in over ~260ms, no black flash, video fills the card box edge-to-edge.
- [ ] Move mouse off — video fades out and resets to first frame.
- [ ] Reload the page and hover a card before videos have warmed up — `poster` should keep the cover image visible during the swap.
- [ ] Quickly hover/unhover repeatedly — no flicker or layout shift.
- [ ] Note: videos are 16:9 vs the ~5:4 card, so `object-fit: cover` still crops ~24% off the sides of each video. Eyeball that no important UI in the videos is being clipped; if so, consider re-exporting the affected video at the card's aspect ratio.

Generated with [Claude Code](https://claude.com/claude-code)
